### PR TITLE
Add testing for the about page

### DIFF
--- a/cypress/e2e/about-flow.cy.js
+++ b/cypress/e2e/about-flow.cy.js
@@ -1,0 +1,56 @@
+describe('empty spec', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/About')
+  })
+
+  it('should have the app image', () => {
+    cy.get('.nav-container > img').should('have.attr', 'alt').should('eq', "puptrainer Logo")
+  })
+
+  it('Should have a title for the about section', () => {
+    cy.get('h2').should('have.text', 'About our project')
+  })
+
+  it('Should have a description for the about page', () => {
+    cy.get('.content').should('have.text', 'We all know how your dog can become such an important part of your family. So we all set out to create a convient dog training app with a variety of commands in one spot. Meet the friendly team and the doggos that inspired the project.')
+  })
+
+  it('should have eight engineers on the page', () => {
+    cy.get('.dog-container').children().should('have.length', 8)
+  })
+
+  it('should have an engineer`s name', () => {
+    cy.get(':nth-child(1) > h3').should('have.text', 'Alex R')
+  })
+
+  it('should have a an engineer`s dog(s) name', () => {
+    cy.get(':nth-child(1) > p').should('have.text', 'Meet their pups Lugnut and Skeeter')
+  })
+
+  it('should have an image of an engineer`s dog', () => {
+    cy.get('.dog-container > :nth-child(1) > img').should('exist')
+  })
+
+  it('should have a nav bar with three links', () => {
+    cy.get('[href="/homepage"]').should('have.text', 'User Profile')
+    cy.get('[href="/About"]').should('have.text', 'About')
+    cy.get('[href="/"]').should('have.text', 'Logout')
+  })
+
+  it('should change url to the homepage when clicking on the User Profile button', () => {
+    cy.get('[href="/homepage"]').click()
+    cy.url().should('include', '/homepage')
+    cy.url().should('eq', 'http://localhost:3000/homepage')
+  })
+
+  it('should be able to log the user out', () => {
+    cy.get('[href="/"]').click()
+    cy.url().should('eq', 'http://localhost:3000/')
+
+    cy.get('.title').should('have.text', 'Welcome to PupTrainer')
+    cy.get('.input-container > :nth-child(1)').should('have.text', 'Please login')
+    cy.get('[placeholder="Username"]').should('have.attr', 'placeholder').should('eq', 'Username')
+    cy.get('[placeholder="Email"]').should('have.attr', 'placeholder').should('eq', 'Email')
+  })
+
+})


### PR DESCRIPTION
## Description 
Adds testing for the 'About' page

#### Where to start?
Start in the 'about-flow.cy.js' file

#### How to test?
In the project directory, you can run:

### `npm start`
Runs the app in the development mode.\
Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
The page will reload when you make changes.

### `npm run cypress`
- click 'about-flow' in the E2E specs section
The test will automatically run.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/89413678/179844981-576381fb-b1c8-4a28-b068-0b9634af8134.png)

#### Type of Change:
- [] Bug fix (non-breaking change which fixes an issue)
- [] Refactor (code is working and without bugs, formatting has been streamlined)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
What steps have you taken to ensure the code is effective?
- [x] Have you used Dev Tools/ ran code in the console?
- [x] Have you ran the Cypress testing suite?

#### Checklist:
- [x] My code follows the style guidelines of this project.
- [x] My commit messages are consistent, descriptive, concise and begin with a verb and capital letter.
- [x] I have performed a self-review of my own code.
- [x] I have added reviewers.
